### PR TITLE
Refactor program to make it more testable

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,2 @@
 version = 3.9.4
-runner.dialect = scala213
+runner.dialect = scala3

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "3.7.2"
 ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "io.adamnfish"
 ThisBuild / organizationName := "adamnfish"

--- a/src/main/scala/io/adamnfish/pcb/Output.scala
+++ b/src/main/scala/io/adamnfish/pcb/Output.scala
@@ -13,24 +13,23 @@ object ConsoleOutput extends Output:
 
 // Test functionality
 
-class TestOutput extends Output {
+class TestOutput extends Output:
   private val output = scala.collection.mutable.Buffer[OutputLine]()
   def stdout(line: String): Unit = output += OutputLine.Stdout(line)
   def stderr(line: String): Unit = output += OutputLine.Stderr(line)
-  
+
   def getAllOutput: List[OutputLine] = output.toList
-  def getStdout: List[String] = output.collect {
-    case OutputLine.Stdout(line) => line
+  def getStdout: List[String] = output.collect { case OutputLine.Stdout(line) =>
+    line
   }.toList
-  def getStderr: List[String] = output.collect {
-    case OutputLine.Stderr(line) => line
+  def getStderr: List[String] = output.collect { case OutputLine.Stderr(line) =>
+    line
   }.toList
   def clear(): Unit = output.clear()
-}
 
-enum OutputLine(val content: String):
-  case Stdout(override val content: String) extends OutputLine(content)
-  case Stderr(override val content: String) extends OutputLine(content)
+enum OutputLine:
+  case Stdout(content: String) extends OutputLine
+  case Stderr(content: String) extends OutputLine
 object OutputLine:
   def out(s: String): OutputLine = Stdout(s)
   def err(s: String): OutputLine = Stderr(s)

--- a/src/main/scala/io/adamnfish/pcb/Output.scala
+++ b/src/main/scala/io/adamnfish/pcb/Output.scala
@@ -1,0 +1,38 @@
+package io.adamnfish.pcb
+
+trait Output:
+  def stdout(line: String): Unit
+  def stderr(line: String): Unit
+
+  def stdoutln(line: String): Unit = stdout(line + "\n")
+  def stderrln(line: String): Unit = stderr(line + "\n")
+
+object ConsoleOutput extends Output:
+  def stdout(line: String): Unit = System.out.print(line)
+  def stderr(line: String): Unit = System.err.print(line)
+
+// Test functionality
+
+class TestOutput extends Output {
+  private val output = scala.collection.mutable.Buffer[OutputLine]()
+  def stdout(line: String): Unit = output += OutputLine.Stdout(line)
+  def stderr(line: String): Unit = output += OutputLine.Stderr(line)
+  
+  def getAllOutput: List[OutputLine] = output.toList
+  def getStdout: List[String] = output.collect {
+    case OutputLine.Stdout(line) => line
+  }.toList
+  def getStderr: List[String] = output.collect {
+    case OutputLine.Stderr(line) => line
+  }.toList
+  def clear(): Unit = output.clear()
+}
+
+enum OutputLine(val content: String):
+  case Stdout(override val content: String) extends OutputLine(content)
+  case Stderr(override val content: String) extends OutputLine(content)
+object OutputLine:
+  def out(s: String): OutputLine = Stdout(s)
+  def err(s: String): OutputLine = Stderr(s)
+  def outln(s: String): OutputLine = Stdout(s + "\n")
+  def errln(s: String): OutputLine = Stderr(s + "\n")


### PR DESCRIPTION
We now separate the CLI from the actual program, and allow different "output" methods. This means the production implementation can use println as normal, while allowing tests to capture the output for later comparison.

This supports integration testing the program against example data.

We also update to Scala 3 here.